### PR TITLE
chore: removed holes text

### DIFF
--- a/Maps3DSamples/ApiDemos/kotlin-app/src/main/java/com/example/maps3dkotlin/mainactivity/MainActivity.kt
+++ b/Maps3DSamples/ApiDemos/kotlin-app/src/main/java/com/example/maps3dkotlin/mainactivity/MainActivity.kt
@@ -141,11 +141,6 @@ fun SampleMenuList(
 
             item {
                 // TODO
-                Text("Need a hole demo", fontStyle = FontStyle.Italic)
-            }
-
-            item {
-                // TODO
                 Text("Flows demos (probably in a different) module?", fontStyle = FontStyle.Italic)
             }
 


### PR DESCRIPTION
The following PR removes the informative text mentioning that we need a hole demo (it is already integrated in the Polygon Demo)

![photo_2025-06-10 11 59 51](https://github.com/user-attachments/assets/570090dd-6e72-4791-86d2-3f0f0abc1b50)
