### PR TITLE
feat: Add EEA Terms of Service notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Contributions are welcome and encouraged! If you'd like to contribute, send us a
 
 This sample uses Google Maps Platform services. Use of Google Maps Platform services through this sample is subject to the Google Maps Platform [Terms of Service].
 
+If your billing address is in the European Economic Area, effective on 8 July 2025, the [Google Maps Platform EEA Terms of Service](https://cloud.google.com/terms/maps-platform/eea) will apply to your use of the Services. Functionality varies by region. [Learn more](https://developers.google.com/maps/comms/eea/faq).
+
 This sample is not a Google Maps Platform Core Service. Therefore, the Google Maps Platform Terms of Service (e.g. Technical Support Services, Service Level Agreements, and Deprecation Policy) do not apply to the code in this sample.
 
 ## Support


### PR DESCRIPTION
This PR adds a notice about the Google Maps Platform EEA Terms of Service to the README.md file.